### PR TITLE
주소 입력창 컴포넌트 수정 : 주소값 props 추가

### DIFF
--- a/apps/owner/src/pages/AddressTest/AddressTest.tsx
+++ b/apps/owner/src/pages/AddressTest/AddressTest.tsx
@@ -1,10 +1,23 @@
 /* 주소 입력창 테스트 페이지 */
+import { useState } from 'react';
 import { InputAddress } from '@daeng-ggu/design-system';
 
 const AddressTest = () => {
+  const [addressForm, setAddressForm] = useState({
+    address1: '',
+    address2: '',
+  });
+  const [detailAddr, setDetailAddr] = useState('');
+
   return (
     <div className='p-8'>
-      <InputAddress label='주소' />
+      <InputAddress
+        label='주소'
+        addressForm={addressForm}
+        setAddressForm={setAddressForm}
+        detailAddr={detailAddr}
+        setDetailAddr={setDetailAddr}
+      />
     </div>
   );
 };

--- a/packages/design-system/components/InputAddress/InputAddress.tsx
+++ b/packages/design-system/components/InputAddress/InputAddress.tsx
@@ -5,25 +5,40 @@ import MySearchIcon from '../Icons/MySearchIcon';
 import Input from '../Input/Input';
 
 import SearchAddress from './SearchAddress';
+
+export type AddressForm = {
+  address1: string;
+  address2: string;
+};
+
 interface Props {
-  label: string;
+  label?: string;
+  addressForm: AddressForm;
+  detailAddr: string;
+  setAddressForm: (_form: AddressForm) => void;
+  setDetailAddr: (_detail: string) => void;
 }
 
 /*
 컴포넌트 사용 예시
 label은 안넘겨줘도 됨
 
-<InputAddress label='주소' />
+<InputAddress label='주소'
+        addressForm={addressForm}
+        setAddressForm={setAddressForm}
+        detailAddr={detailAddr}
+        setDetailAddr={setDetailAddr}
+        />
 */
 
-const InputAddress = ({ label = '' }: Props) => {
+const InputAddress = ({
+  label = '',
+  addressForm = { address1: '', address2: '' },
+  detailAddr = '',
+  setAddressForm,
+  setDetailAddr,
+}: Props) => {
   const [isOpen, setIsOpen] = useState(false);
-  const [addressForm, setAddressForm] = useState({
-    address1: '',
-    address2: '',
-  });
-  const [detailAddr, setDetailAddr] = useState('');
-
   const handleOpen = () => {
     setIsOpen((prev) => !prev);
   };

--- a/packages/design-system/components/InputAddress/SearchAddress.tsx
+++ b/packages/design-system/components/InputAddress/SearchAddress.tsx
@@ -1,7 +1,8 @@
 /* 주소 검색용 팝업창 (daum api 사용) */
 import DaumPostcode, { Address } from 'react-daum-postcode';
 
-// import getAddress from '../../utils/getAddress';
+import getAddress from '../../utils/getAddress';
+
 import CloseIcon from '../Icons/CloseIcon';
 
 interface Props {
@@ -12,8 +13,8 @@ interface Props {
 const SearchAddress = ({ setAddressForm, handleOpen }: Props) => {
   const handleComplete = (data: Address) => {
     const address1 = `${data.sido} ${data.sigungu} ${data.bname}`; //서울 강남구 대치동
-    const address2 = data.address; //서울 강남구 선릉로 428
-    // const address2 = getAddress(data); //서울 강남구 선릉로 428 (대치동)
+    const address2 = getAddress(data); //서울 강남구 선릉로 428 (대치동)
+    // const address2 = data.address; //서울 강남구 선릉로 428
     console.log(data);
     console.log(address1);
     console.log(address2);


### PR DESCRIPTION
# Pull Request

## PR 개요

- 주소 입력창 컴포넌트
- **props로 보내줄 수 있는 값**
    1. label?: string;
    
**추가된 props**
    2. addressForm: AddressForm;
    3. detailAddr: string;
    4. setAddressForm: (form: AddressForm) => void;
    5. setDetailAddr: (detail: string) => void;
 
- **사용예시**
    - 테스트용 url : /address/test

## Screenshots

<!--
  If capable,
  If there are UI changes, include before and after screenshots.
  This helps reviewers understand the visual impact of the changes.
-->
