### PR TITLE
공용 모달 컴포넌트 추가

### DIFF
--- a/apps/owner/src/App.tsx
+++ b/apps/owner/src/App.tsx
@@ -1,11 +1,13 @@
 import { Outlet } from 'react-router';
 import { Layout } from '@daeng-ggu/design-system';
+import { ModalContainer } from '@daeng-ggu/shared';
 
 import OwnerBottomTabBar from './components/BottomTabBar/OwnerBottomTabBar';
 
 function App() {
   return (
     <Layout tab={<OwnerBottomTabBar />}>
+      <ModalContainer />
       <Outlet />
     </Layout>
   );

--- a/apps/owner/src/components/ModalContainer/ModalContainer.tsx
+++ b/apps/owner/src/components/ModalContainer/ModalContainer.tsx
@@ -1,0 +1,11 @@
+// import useModalStore from '@/stores/useModalStore';
+
+// const ModalContainer = () => {
+//   const { Component, props, isOpen, close } = useModalStore();
+
+//   if (!isOpen || !Component) return null;
+
+//   return <Component {...props} onClose={close} />;
+// };
+
+// export default ModalContainer;

--- a/apps/owner/src/pages/MainPage/MainPage.tsx
+++ b/apps/owner/src/pages/MainPage/MainPage.tsx
@@ -1,12 +1,26 @@
 // import { MapIcon, MyPageIcon, SendIcon } from '@daeng-ggu/design-system';
 
+import { Modal } from '@daeng-ggu/design-system';
+import { useModalStore } from '@daeng-ggu/shared';
+
 // import OwnerBottomTabBar from '@/components/BottomTabBar/OwnerBottomTabBar';
 
 const MainPage = () => {
+  const { show } = useModalStore();
+  const onClick = () => {
+    show(Modal, {
+      title: 'hello',
+      description: 'world',
+      onConfirm: () => {},
+      confirmText: 'confirm',
+      cancelText: 'cancel',
+    });
+  };
   return (
     <div>
       <div className='text-xl font-bold'>MainPagee</div>
       <div className='font-pretendard-variable text-xl'></div>
+      <button onClick={onClick}>open modal</button>
     </div>
   );
 };

--- a/apps/owner/src/stores/useModalStore.tsx
+++ b/apps/owner/src/stores/useModalStore.tsx
@@ -1,0 +1,33 @@
+// import { FC } from 'react';
+// import { ModalProps } from '@daeng-ggu/shared';
+// import { create } from 'zustand';
+
+// type PartialModalProps = Partial<ModalProps>;
+
+// interface ModalState {
+//   Component: FC<ModalProps> | null; // 모달로 사용할 컴포넌트
+//   props: PartialModalProps; // 모달에 전달할 props
+//   isOpen: boolean; // 모달 열림 여부
+//   show: (_Component: FC<ModalProps>, _props?: PartialModalProps) => void; // 모달 열기
+//   close: () => void; // 모달 닫기
+// }
+
+// const useModalStore = create<ModalState>((set) => ({
+//   Component: null,
+//   props: {},
+//   isOpen: false,
+//   show: (Component, props = {}) =>
+//     set({
+//       Component,
+//       props,
+//       isOpen: true,
+//     }),
+//   close: () =>
+//     set({
+//       Component: null,
+//       props: {},
+//       isOpen: false,
+//     }),
+// }));
+
+// export default useModalStore;

--- a/apps/storybook/src/stories/Modal.stories.tsx
+++ b/apps/storybook/src/stories/Modal.stories.tsx
@@ -1,0 +1,53 @@
+import { Modal } from '@daeng-ggu/design-system';
+import { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta<typeof Modal> = {
+  title: 'daeng-ggu/Modal',
+  component: Modal,
+  argTypes: {
+    title: {
+      control: 'text',
+      description: '모달의 제목',
+      defaultValue: 'Modal Title',
+    },
+    description: {
+      control: 'text',
+      description: '모달의 설명',
+      defaultValue: 'This is a modal description.',
+    },
+    confirmText: {
+      control: 'text',
+      description: '확인 버튼 텍스트',
+      defaultValue: 'Confirm',
+    },
+    cancelText: {
+      control: 'text',
+      description: '취소 버튼 텍스트',
+      defaultValue: 'Cancel',
+    },
+    onClose: {
+      action: 'clicked close',
+      description: '취소 버튼 클릭 이벤트',
+    },
+    onConfirm: {
+      action: 'clicked confirm',
+      description: '확인 버튼 클릭 이벤트',
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Modal>;
+
+export const Default: Story = {
+  args: {
+    title: 'Modal Title',
+    description: 'This is a modal description.',
+    confirmText: 'Confirm',
+    cancelText: 'Cancel',
+    onClose: () => console.log('Close button clicked'),
+    onConfirm: () => console.log('Confirm button clicked'),
+  },
+  render: (args) => <Modal {...args}></Modal>,
+};

--- a/packages/design-system/components/Modal/Modal.tsx
+++ b/packages/design-system/components/Modal/Modal.tsx
@@ -1,0 +1,35 @@
+import { ModalProps, useClickOutside } from '@daeng-ggu/shared';
+
+import TypeTwoButton from '../TypeTwoButton/TypeTwoButton';
+
+const Modal = ({ onConfirm, description, onClose, confirmText, cancelText, title }: ModalProps) => {
+  const { targetRef } = useClickOutside<HTMLDivElement>(onClose);
+
+  return (
+    <>
+      <div className='fixed z-40 flex h-[100vh] w-full min-w-[32rem] max-w-[48rem] flex-col items-center justify-center bg-black/20'>
+        <section ref={targetRef} className='z-50 w-[80%] rounded-md bg-white px-[4rem] py-[2.4rem]'>
+          <div className='flex w-full flex-col items-center justify-center gap-8'>
+            <h3 className='text-sub_h2 font-semibold'>{title}</h3>
+            <span className='w-[15rem] text-body3 text-gray-700'>{description}</span>
+          </div>
+          <div className='flex justify-center gap-[0.8rem]'>
+            <TypeTwoButton
+              className='h-[2.5rem] w-[8rem] rounded-md border-none bg-gray-50 text-gray-700'
+              onClick={onClose}
+              text={cancelText}
+            />
+            <TypeTwoButton
+              className='h-[2.5rem] w-[8rem] rounded-md border-none'
+              color='bg-primary'
+              onClick={onConfirm}
+              text={confirmText}
+            />
+          </div>
+        </section>
+      </div>
+    </>
+  );
+};
+
+export default Modal;

--- a/packages/design-system/components/TypeTwoButton/TypeTwoButton.tsx
+++ b/packages/design-system/components/TypeTwoButton/TypeTwoButton.tsx
@@ -1,10 +1,13 @@
+import { cn } from '../../lib/utils';
+
 interface TypeTwoButtonProps {
   text?: string;
   color?: string;
   onClick?: () => void;
+  className?: string;
 }
 
-const TypeTwoButton = ({ text, color, onClick }: TypeTwoButtonProps) => {
+const TypeTwoButton = ({ className, text, color, onClick }: TypeTwoButtonProps) => {
   const textColor =
     color === 'bg-primary'
       ? 'text-white'
@@ -14,7 +17,10 @@ const TypeTwoButton = ({ text, color, onClick }: TypeTwoButtonProps) => {
 
   return (
     <button
-      className={`h-[48px] w-full max-w-[280px] rounded border px-4 py-2 text-body2 font-bold hover:bg-opacity-80 ${color} ${textColor}`}
+      className={cn(
+        `mt-6 h-[48px] w-full max-w-[280px] rounded border px-4 py-2 text-body2 font-bold hover:bg-opacity-80 ${color} ${textColor}`,
+        className,
+      )}
       onClick={onClick}
     >
       {text ? text : '내용없음'}

--- a/packages/design-system/index.ts
+++ b/packages/design-system/index.ts
@@ -45,6 +45,7 @@ import StarHalfIcon from './components/Icons/StarHalfIcon';
 import Input from './components/Input/Input';
 import InputAddress from './components/InputAddress/InputAddress';
 import Layout from './components/Layout/Layout';
+import Modal from './components/Modal/Modal';
 import PageContainer from './components/PageContainer/PageContainer';
 import UserProfileImage from './components/ProfileImage/UserProfileImage';
 import { Progress } from './components/Progress/progress';
@@ -56,6 +57,7 @@ import TextArea from './components/TextArea/TextArea';
 import TimeSelect from './components/TimeSelect/TimeSelect';
 import TypeOneButton from './components/TypeOneButton/TypeOneButton';
 import TypeTwoButton from './components/TypeTwoButton/TypeTwoButton';
+
 export {
   CategoryTab,
   ImageSlider,
@@ -71,6 +73,7 @@ export {
   MiniButton,
   BackIcon,
   BellAlertIcon,
+  Modal,
   BellIcon,
   CloseIcon,
   Layout,

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -10,6 +10,7 @@
     "lint": "eslint \"**/*.ts\""
   },
   "dependencies": {
+    "@daeng-ggu/shared": "workspace:*",
     "@radix-ui/react-dropdown-menu": "^2.1.2",
     "@radix-ui/react-progress": "^1.1.0",
     "@radix-ui/react-radio-group": "^1.2.1",

--- a/packages/shared/eslint.config.js
+++ b/packages/shared/eslint.config.js
@@ -7,7 +7,7 @@ import tseslint from 'typescript-eslint';
 import eslintConfigPrettier from 'eslint-config-prettier';
 import prettierPlugin from 'eslint-plugin-prettier';
 import eslintPluginJsxA11y from 'eslint-plugin-jsx-a11y';
-import noRelativeImportPaths from 'eslint-plugin-no-relative-import-paths';
+// import noRelativeImportPaths from 'eslint-plugin-no-relative-import-paths';
 import simpleImportSort from 'eslint-plugin-simple-import-sort';
 
 export default tseslint.config(
@@ -43,10 +43,10 @@ export default tseslint.config(
       'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
       'prettier/prettier': 'error',
       // 상대경로 import 금지, rootDir 기준으로 @로 시작하는 절대경로로 변경
-      'no-relative-import-paths/no-relative-import-paths': [
-        'warn',
-        { allowSameFolder: true, rootDir: 'src', prefix: '@' },
-      ],
+      // 'no-relative-import-paths/no-relative-import-paths': [
+      //   'warn',
+      //   { allowSameFolder: true, rootDir: 'src', prefix: '@' },
+      // ],
 
       // 유효한 aria-* 속성만 사용
       'jsx-a11y/alt-text': [

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -10,7 +10,8 @@
   },
   "dependencies": {
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "zustand": "^5.0.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.15.0",

--- a/packages/shared/src/components/ModalContainer/ModalContainer.tsx
+++ b/packages/shared/src/components/ModalContainer/ModalContainer.tsx
@@ -1,0 +1,13 @@
+import { ModalProps } from 'src/types/modal';
+
+import useModalStore from '../../stores/useModalStore';
+
+const ModalContainer = () => {
+  const { Component, props, isOpen, close } = useModalStore();
+  const p = props as ModalProps;
+  if (!isOpen || !Component) return null;
+
+  return <Component {...p} onClose={close} />;
+};
+
+export default ModalContainer;

--- a/packages/shared/src/hooks/useClickOutside.ts
+++ b/packages/shared/src/hooks/useClickOutside.ts
@@ -1,0 +1,35 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+const useClickOutside = <T extends Node = HTMLElement>(callback: () => void) => {
+  const ref = useRef<T>(null);
+
+  const handleClickOutside = useCallback(
+    (event: MouseEvent) => {
+      if (ref.current && !ref.current.contains(event.target as Node)) {
+        callback();
+      }
+    },
+    [callback],
+  );
+
+  useEffect(() => {
+    document.addEventListener('mousedown', handleClickOutside);
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [handleClickOutside]);
+
+  // 추후에 리팩토링
+  //   useEffect(() => {
+  //     const unsubscribe = router.subscribe(callback);
+
+  //     return () => {
+  //       unsubscribe();
+  //     };
+  //   }, [callback]);
+
+  return { targetRef: ref };
+};
+
+export default useClickOutside;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,1 +1,5 @@
 export { default as RouterErrorFallback } from './components/RouterErrorFallback/RouterErrorFallback';
+export type { ModalProps } from './types/modal';
+export { default as useModalStore } from './stores/useModalStore';
+export { default as ModalContainer } from './components/ModalContainer/ModalContainer';
+export { default as useClickOutside } from './hooks/useClickOutside';

--- a/packages/shared/src/stores/useModalStore.ts
+++ b/packages/shared/src/stores/useModalStore.ts
@@ -1,0 +1,33 @@
+import { FC } from 'react';
+import { ModalProps } from '@daeng-ggu/shared';
+import { create } from 'zustand';
+
+type PartialModalProps = Partial<ModalProps>;
+
+interface ModalState {
+  Component: FC<ModalProps> | null; // 모달로 사용할 컴포넌트
+  props: PartialModalProps; // 모달에 전달할 props
+  isOpen: boolean; // 모달 열림 여부
+  show: (_Component: FC<ModalProps>, _props: PartialModalProps) => void; // 모달 열기
+  close: () => void; // 모달 닫기
+}
+
+const useModalStore = create<ModalState>((set) => ({
+  Component: null,
+  props: {},
+  isOpen: false,
+  show: (Component, props = {}) =>
+    set({
+      Component,
+      props,
+      isOpen: true,
+    }),
+  close: () =>
+    set({
+      Component: null,
+      props: {},
+      isOpen: false,
+    }),
+}));
+
+export default useModalStore;

--- a/packages/shared/src/types/modal.ts
+++ b/packages/shared/src/types/modal.ts
@@ -1,0 +1,8 @@
+export interface ModalProps {
+  onClose: () => void;
+  onConfirm: () => void;
+  title: string;
+  description: string;
+  confirmText: string;
+  cancelText: string;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -364,6 +364,7 @@ __metadata:
   resolution: "@daeng-ggu/design-system@workspace:packages/design-system"
   dependencies:
     "@daeng-ggu/eslint-config": "npm:*"
+    "@daeng-ggu/shared": "workspace:*"
     "@daeng-ggu/tailwind-config": "npm:*"
     "@daeng-ggu/typescript-config": "npm:*"
     "@radix-ui/react-dropdown-menu": "npm:^2.1.2"
@@ -550,6 +551,7 @@ __metadata:
     typescript: "npm:~5.6.2"
     typescript-eslint: "npm:^8.15.0"
     vite: "npm:^6.0.1"
+    zustand: "npm:^5.0.1"
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2002,6 +2002,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/rollup-win32-x64-msvc@npm:4.28.0":
+  version: 4.28.0
+  resolution: "@rollup/rollup-win32-x64-msvc@npm:4.28.0"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@sentry-internal/browser-utils@npm:8.42.0":
   version: 8.42.0
   resolution: "@sentry-internal/browser-utils@npm:8.42.0"


### PR DESCRIPTION
# Pull Request

## PR 개요

- 공용 모달 컴포넌트 추가
- shared에 useClickOutside를 추가했습니다.
- 디자인시스템의 Modal을 사용하면 됩니다.

- 모달 사용법
```js
  const { show } = useModalStore();
  const onClick = () => {
    show(Modal, {
      title: 'hello',
      description: 'world',
      onConfirm: () => {},
      confirmText: 'confirm',
      cancelText: 'cancel',
    });
  };


```

## Screenshots

<!--
  If capable,
  If there are UI changes, include before and after screenshots.
  This helps reviewers understand the visual impact of the changes.
-->
