### PR TITLE
동영상 업로드 구현(ImageUploader컴포넌트에 동영상 업로드 기능 추가)

### DIFF
--- a/apps/owner/src/pages/InputTest/InputTest.tsx
+++ b/apps/owner/src/pages/InputTest/InputTest.tsx
@@ -13,6 +13,8 @@ const InputTest = () => {
     'https://blog.malcang.com/wp-content/uploads/2024/03/1-1.png',
     'https://blog.malcang.com/wp-content/uploads/2024/03/1-1.png',
   ];
+  const [video, setVideo] = useState<File | null>(null);
+  const initialVideo = 'https://cdnvod.yonhapnews.co.kr/yonhapnewsvod/202412/MYH20241205018500704_700M1.mp4';
   const [image, setImage] = useState<File | undefined>(undefined);
   const initialProfileImg = 'https://blog.malcang.com/wp-content/uploads/2024/03/1-1.png';
 
@@ -72,7 +74,16 @@ const InputTest = () => {
       <hr className='my-4' />
       <SearchBar keyword={keyword} onChange={handleKeywordChange} />
       <hr className='my-4' />
-      <ImageUploader imgList={imgList} setImgList={setImgList} label='사진' initialImgList={initialImgList} />
+      <ImageUploader
+        mode='both'
+        imgList={imgList}
+        setImgList={setImgList}
+        label='사진'
+        initialImgList={initialImgList}
+        video={video}
+        setVideo={setVideo}
+        initialVideo={initialVideo}
+      />
       <hr className='my-4' />
       <ProfileImgUploader image={image} setImage={setImage} initialImageUrl={initialProfileImg} />
     </div>

--- a/packages/design-system/components/FileUploader/ImageSlider.tsx
+++ b/packages/design-system/components/FileUploader/ImageSlider.tsx
@@ -7,38 +7,49 @@ import { Swiper, SwiperSlide } from 'swiper/react';
 import 'swiper/swiper-bundle.css';
 // Import Swiper styles
 import './swiperStyles.css';
-interface SliderProps {
-  list: string[];
+export interface SliderItem {
+  // type: 'image' | 'video';
+  type: string;
+  src: string;
 }
+
+interface SliderProps {
+  list: SliderItem[];
+}
+
 const ImageSlider = ({ list }: SliderProps) => {
   return (
-    <>
-      <Swiper
-        style={
-          {
-            '--swiper-navigation-color': 'rgba(var(--gray800)',
-            '--swiper-navigation-size': '2rem',
-            '--swiper-pagination-color': 'rgba(var(--gray800)',
-          } as CSSProperties
-        }
-        zoom={true}
-        navigation={true}
-        loop={true}
-        pagination={{
-          clickable: true,
-        }}
-        modules={[Zoom, Navigation, Pagination]}
-        className='mySwiper overflow-hidden rounded-md border border-gray-100'
-      >
-        {list.map((item, index) => (
-          <SwiperSlide key={index}>
-            <div className='swiper-zoom-container'>
-              <img src={item} alt={`이미지 ${index}`} className='object-contain' />
-            </div>
-          </SwiperSlide>
-        ))}
-      </Swiper>
-    </>
+    <Swiper
+      style={
+        {
+          '--swiper-navigation-color': 'rgba(var(--gray800)',
+          '--swiper-navigation-size': '2rem',
+          '--swiper-pagination-color': 'rgba(var(--gray800)',
+        } as CSSProperties
+      }
+      zoom={true}
+      navigation={true}
+      loop={true}
+      pagination={{
+        clickable: true,
+      }}
+      modules={[Zoom, Navigation, Pagination]}
+      className='mySwiper overflow-hidden rounded-md border border-gray-100'
+    >
+      {list.map((item, index) => (
+        <SwiperSlide key={index}>
+          <div className='swiper-zoom-container'>
+            {item.type === 'video' ? (
+              <video controls className='object-contain' src={item.src}>
+                {/* Your browser does not support the video tag. */}
+              </video>
+            ) : (
+              <img src={item.src} alt={`이미지 ${index}`} className='object-contain' />
+            )}
+          </div>
+        </SwiperSlide>
+      ))}
+    </Swiper>
   );
 };
 export default ImageSlider;


### PR DESCRIPTION
# Pull Request

## PR 개요

- ImageUploader 컴포넌트를 동영상 업로드도 가능하게 수정
- **props로 보내줄 수 있는 값**  
- mode: 'img' | 'both'; //이미지만 업로드하는 mode 와 동영상도 업로드 가능한 mode(포트폴리오 등록시 사용)
  initialImgList?: string[];
  initialVideo?: string;
  imgList?: File[];
  setImgList?: Dispatch<SetStateAction<File[]>>;
  video?: File | null;
  setVideo?: Dispatch<SetStateAction<File | null>>;
  label?: string;
- <ImageUploader
        mode='both'
        ...
    />
- 동영상은 1개까지만 업로드 가능하도록 제한
## Screenshots
![스크린샷 2024-12-06 오후 1 37 32](https://github.com/user-attachments/assets/8092a6a6-2213-4223-b12a-01b16c25527e)

<!--
  If capable,
  If there are UI changes, include before and after screenshots.
  This helps reviewers understand the visual impact of the changes.
-->
