### PR TITLE
하단 탭 바 개선 및 스와이퍼 css 중복 문제 해결

### DIFF
--- a/apps/owner/src/components/BottomTabBar/OwnerBottomTabBar.tsx
+++ b/apps/owner/src/components/BottomTabBar/OwnerBottomTabBar.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router';
 import { BottomTabBar, FeedIcon, MapIcon, MyPageIcon, ReservationIcon, SendIcon } from '@daeng-ggu/design-system';
 
 import { cn } from '@/lib/utils';
@@ -12,13 +14,19 @@ import { useOwnerBottomTabStore } from '@/stores/bottomTabStore';
 const ownerTabs = [
   { label: '디자이너 찾기', icon: MapIcon, path: '/' },
   { label: '피드', icon: FeedIcon, path: '/feed' },
-  { label: '견적 요청', icon: SendIcon, path: '/bid' },
-  { label: '예약 현황', icon: ReservationIcon, path: '/address/test' },
-  { label: '마이페이지', icon: MyPageIcon, path: '/my' },
+  { label: '견적 요청', icon: SendIcon, path: '/bid/status' },
+  { label: '예약 현황', icon: ReservationIcon, path: '/reservation' },
+  { label: '마이페이지', icon: MyPageIcon, path: '/profile' },
 ];
 
 const OwnerBottomTabBar = () => {
   const { activePath, setActivePath } = useOwnerBottomTabStore();
+  const location = useLocation();
+
+  // url 바뀔때마다 activePath update
+  useEffect(() => {
+    setActivePath(`/${location.pathname.split('/', 2)[1]}`);
+  }, [location.pathname, setActivePath]);
 
   return (
     <BottomTabBar

--- a/apps/owner/src/components/BottomTabBar/OwnerBottomTabBar.tsx
+++ b/apps/owner/src/components/BottomTabBar/OwnerBottomTabBar.tsx
@@ -2,21 +2,21 @@ import { useEffect } from 'react';
 import { useLocation } from 'react-router';
 import { BottomTabBar, FeedIcon, MapIcon, MyPageIcon, ReservationIcon, SendIcon } from '@daeng-ggu/design-system';
 
+import ROUTES from '@/constants/routes';
 import { cn } from '@/lib/utils';
 import { useOwnerBottomTabStore } from '@/stores/bottomTabStore';
 /* to-do
 
 * 로그인 상태에 따라 마이페이지/로그인 label 변경
-* path 변경
 
  */
 
 const ownerTabs = [
-  { label: '디자이너 찾기', icon: MapIcon, path: '/' },
-  { label: '피드', icon: FeedIcon, path: '/feed' },
-  { label: '견적 요청', icon: SendIcon, path: '/bid/status' },
-  { label: '예약 현황', icon: ReservationIcon, path: '/reservation' },
-  { label: '마이페이지', icon: MyPageIcon, path: '/profile' },
+  { label: '디자이너 찾기', icon: MapIcon, path: ROUTES.main },
+  { label: '피드', icon: FeedIcon, path: ROUTES.feed },
+  { label: '견적 요청', icon: SendIcon, path: ROUTES.bid },
+  { label: '예약 현황', icon: ReservationIcon, path: ROUTES.reservation },
+  { label: '마이페이지', icon: MyPageIcon, path: ROUTES.profile },
 ];
 
 const OwnerBottomTabBar = () => {

--- a/apps/owner/src/constants/routes.ts
+++ b/apps/owner/src/constants/routes.ts
@@ -2,6 +2,9 @@ const ROUTES = {
   main: '/',
   progress: '/progress',
   bid: '/bid',
+  feed: '/feed',
+  reservation: '/reservation',
+  profile: '/profile',
 } as const;
 
 export default ROUTES;

--- a/apps/owner/src/pages/ReviewDetailPage/ReviewDetailPage.tsx
+++ b/apps/owner/src/pages/ReviewDetailPage/ReviewDetailPage.tsx
@@ -132,7 +132,7 @@ const ReviewDetail = () => {
           setActiveIndex(swiper.activeIndex);
           navigate(`/profile/review/${reviews[swiper.activeIndex].reviewId}`, { replace: true, state: { reviews } });
         }}
-        className='flex-1'
+        className='mySwiper2 flex-1'
         modules={[Pagination]}
         preventClicksPropagation={true}
       >

--- a/apps/owner/src/pages/ReviewDetailPage/swiperStyle.css
+++ b/apps/owner/src/pages/ReviewDetailPage/swiperStyle.css
@@ -1,6 +1,30 @@
 /* swiperStyle.css */
 
-.swiper-pagination {
+.mySwiper2 .swiper-pagination {
+  padding-bottom: 140px;
+  width: 100%;
+  text-align: center;
+  display: flex;
+  justify-content: center;
+  gap: 6px;
+}
+
+.mySwiper2 .swiper-pagination-bullet {
+  background: rgba(var(--secondary));
+  opacity: 1;
+  width: 12px;
+  height: 12px;
+  outline: none;
+  border-width: 0;
+  border: none;
+  box-shadow: none;
+}
+
+.mySwiper2 .swiper-pagination-bullet-active {
+  background: rgba(var(--primary));
+}
+
+/* .swiper-pagination {
   padding-bottom: 140px;
   width: 100%;
   text-align: center;
@@ -22,4 +46,4 @@
 
 .swiper-pagination-bullet-active {
   background: rgba(var(--primary));
-}
+} */

--- a/apps/owner/src/stores/bottomTabStore.tsx
+++ b/apps/owner/src/stores/bottomTabStore.tsx
@@ -1,11 +1,20 @@
 import { create } from 'zustand';
+import { createJSONStorage, persist } from 'zustand/middleware';
 
 interface BottomTabState {
   activePath: string;
   setActivePath: (_path: string) => void;
 }
 
-export const useOwnerBottomTabStore = create<BottomTabState>((set) => ({
-  activePath: '',
-  setActivePath: (_path) => set({ activePath: _path }),
-}));
+export const useOwnerBottomTabStore = create<BottomTabState>()(
+  persist<BottomTabState>(
+    (set) => ({
+      activePath: '',
+      setActivePath: (_path) => set({ activePath: _path }),
+    }),
+    {
+      name: 'bottomTab',
+      storage: createJSONStorage(() => sessionStorage),
+    },
+  ),
+);

--- a/packages/design-system/components/FileUploader/ImageSlider.tsx
+++ b/packages/design-system/components/FileUploader/ImageSlider.tsx
@@ -34,7 +34,7 @@ const ImageSlider = ({ list }: SliderProps) => {
         clickable: true,
       }}
       modules={[Zoom, Navigation, Pagination]}
-      className='mySwiper overflow-hidden rounded-md border border-gray-100'
+      className='mySwiper1 overflow-hidden rounded-md border border-gray-100'
     >
       {list.map((item, index) => (
         <SwiperSlide key={index}>

--- a/packages/design-system/components/FileUploader/swiperStyles.css
+++ b/packages/design-system/components/FileUploader/swiperStyles.css
@@ -3,19 +3,19 @@
   aspect-ratio: 3/2;
 }
 
-.swiper-wrapper {
+.mySwiper1 .swiper-wrapper {
   align-items: center;
 }
 
-.swiper-slide {
+.mySwiper1 .swiper-slide {
   overflow: hidden;
 }
-.swiper-button-next:after {
+.mySwiper1 .swiper-button-next:after {
   text-shadow: 0 0 4px white;
 }
-.swiper-button-prev:after {
+.mySwiper1 .swiper-button-prev:after {
   text-shadow: 0 0 4px white;
 }
-.swiper-pagination-bullet {
+.mySwiper1 .swiper-pagination-bullet {
   box-shadow: 0 0 3px white;
 }


### PR DESCRIPTION
# Pull Request

## PR 개요

> 하단 탭 바 개선
- 각 탭 path 수정
- activePath 상태 persist로 관리(새로고침해도 유지되도록)
- url에 따라 activePath update

> 스와이퍼 css 중복 문제 해결
- '리뷰 조회'와 '업로드된 이미지 조회(ImageSlider)'에서 swiper를 사용하는데
- css가 중복으로 적용되어 원하지 않은 스타일 적용되는 문제 발생
- 구분하기 위한 className을 추가해서 문제 해결

## Screenshots

<!--
  If capable,
  If there are UI changes, include before and after screenshots.
  This helps reviewers understand the visual impact of the changes.
-->
